### PR TITLE
Add timeout to execution and expose command output type

### DIFF
--- a/dist/command-output.d.ts
+++ b/dist/command-output.d.ts
@@ -1,6 +1,7 @@
 declare enum CommandOutputType {
     Success = 0,
-    Error = 1
+    Error = 1,
+    TimedOut = 2
 }
 declare class CommandOutput {
     type: CommandOutputType;

--- a/dist/command-output.js
+++ b/dist/command-output.js
@@ -5,8 +5,8 @@ var CommandOutputType;
 (function (CommandOutputType) {
     CommandOutputType[CommandOutputType["Success"] = 0] = "Success";
     CommandOutputType[CommandOutputType["Error"] = 1] = "Error";
-})(CommandOutputType || (CommandOutputType = {}));
-exports.CommandOutputType = CommandOutputType;
+    CommandOutputType[CommandOutputType["TimedOut"] = 2] = "TimedOut";
+})(CommandOutputType || (exports.CommandOutputType = CommandOutputType = {}));
 class CommandOutput {
     constructor(type, value) {
         this.type = type;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,5 @@
 import { PipeExecuteStrategy } from "./pipe-execute-strategy";
 import { RegularExecuteStrategy } from "./regular-execute-strategy";
 import { CommandExecutor } from "./command-executor";
-export { PipeExecuteStrategy, RegularExecuteStrategy, CommandExecutor };
+import { CommandOutputType } from "./command-output";
+export { PipeExecuteStrategy, RegularExecuteStrategy, CommandExecutor, CommandOutputType };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.CommandExecutor = exports.RegularExecuteStrategy = exports.PipeExecuteStrategy = void 0;
+exports.CommandOutputType = exports.CommandExecutor = exports.RegularExecuteStrategy = exports.PipeExecuteStrategy = void 0;
 const pipe_execute_strategy_1 = require("./pipe-execute-strategy");
 Object.defineProperty(exports, "PipeExecuteStrategy", { enumerable: true, get: function () { return pipe_execute_strategy_1.PipeExecuteStrategy; } });
 const regular_execute_strategy_1 = require("./regular-execute-strategy");
 Object.defineProperty(exports, "RegularExecuteStrategy", { enumerable: true, get: function () { return regular_execute_strategy_1.RegularExecuteStrategy; } });
 const command_executor_1 = require("./command-executor");
 Object.defineProperty(exports, "CommandExecutor", { enumerable: true, get: function () { return command_executor_1.CommandExecutor; } });
+const command_output_1 = require("./command-output");
+Object.defineProperty(exports, "CommandOutputType", { enumerable: true, get: function () { return command_output_1.CommandOutputType; } });

--- a/dist/pipe-execute-strategy.d.ts
+++ b/dist/pipe-execute-strategy.d.ts
@@ -6,10 +6,12 @@ declare class PipeExecuteStrategy implements ExecuteStrategy {
     protected pipePath: string;
     protected outputPath: string;
     protected commandSerializer: CommandSerializer;
+    protected executionTimeout: number;
     constructor();
     private getFileLastModified;
     private getCachedOutput;
     private sleep;
+    private waitForOutputWithTimeout;
     execute: (cmd: string) => CommandOutput;
     static builder: () => {
         container: PipeExecuteStrategy;
@@ -17,6 +19,7 @@ declare class PipeExecuteStrategy implements ExecuteStrategy {
         withPipePath: (pipePath: string) => this;
         withCache: (useCache: boolean) => this;
         withOutputPath: (outputPath: string) => this;
+        withExecutionTimeout: (executionTimeout: number) => this;
         build: () => ExecuteStrategy;
     };
     static PipeExecuteStrategyBuilder: {
@@ -26,6 +29,7 @@ declare class PipeExecuteStrategy implements ExecuteStrategy {
             withPipePath: (pipePath: string) => this;
             withCache: (useCache: boolean) => this;
             withOutputPath: (outputPath: string) => this;
+            withExecutionTimeout: (executionTimeout: number) => this;
             build: () => ExecuteStrategy;
         };
     };

--- a/src/command-output.ts
+++ b/src/command-output.ts
@@ -1,6 +1,7 @@
 enum CommandOutputType {
   Success = 0,
   Error = 1,
+  TimedOut = 2,
 }
 
 class CommandOutput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { PipeExecuteStrategy } from "./pipe-execute-strategy";
 import { RegularExecuteStrategy } from "./regular-execute-strategy";
 import { CommandExecutor } from "./command-executor";
+import { CommandOutputType } from "./command-output";
 
-export { PipeExecuteStrategy, RegularExecuteStrategy, CommandExecutor };
+export { PipeExecuteStrategy, RegularExecuteStrategy, CommandExecutor, CommandOutputType };

--- a/src/pipe-execute-strategy.ts
+++ b/src/pipe-execute-strategy.ts
@@ -6,17 +6,20 @@ import { CommandSerializer, JsonSerializer } from "./command-serializer";
 const GENERIC_OUTPUT_PATH = "output.txt";
 const PIPE_OUTPUT_CACHE_MINUTES = 3;
 const PIPE_WAIT_SLEEP_TIME = 100; // 100ms
+const DEFAULT_EXECUTION_TIMEOUT = 10000; // 10_000ms = 10s
 
 class PipeExecuteStrategy implements ExecuteStrategy {
   protected useCache: boolean;
   protected pipePath: string;
   protected outputPath: string;
   protected commandSerializer: CommandSerializer;
+  protected executionTimeout: number;
 
   constructor() {
     this.useCache = false;
     this.outputPath = GENERIC_OUTPUT_PATH;
     this.commandSerializer = new JsonSerializer(this.outputPath);
+    this.executionTimeout = DEFAULT_EXECUTION_TIMEOUT;
   }
 
   private getFileLastModified = (filePath: string): number => {
@@ -52,6 +55,40 @@ class PipeExecuteStrategy implements ExecuteStrategy {
     while (Date.now() - start < ms) {}
   };
 
+  private waitForOutputWithTimeout = (lastModified: number) => {
+    const start = Date.now();
+    let didTimeout = false;
+
+    const isTimedOut = () => {
+      const now = Date.now();
+      const diff = now - start;
+      const result = diff > this.executionTimeout;
+      if (result) {
+        didTimeout = true;
+      }
+      return result;
+    }
+
+    // If output path does not exist, wait for it to be created
+    // Edge case, will happen only first time
+    if (!existsSync(this.outputPath)) {
+      while (!existsSync(this.outputPath) && !isTimedOut()) {
+        this.sleep(PIPE_WAIT_SLEEP_TIME);
+      }
+    } else {
+      // Otherwise wait for the file to be modified
+      while (true && !isTimedOut()) {
+        const lastModifiedUpdated = this.getFileLastModified(this.outputPath);
+        if (lastModified !== lastModifiedUpdated) {
+          break;
+        }
+        this.sleep(PIPE_WAIT_SLEEP_TIME);
+      }
+    }
+    
+    return didTimeout;
+  };
+
   execute = (cmd: string): CommandOutput => {
     const cachedOutput = this.useCache
       ? this.getCachedOutput(this.outputPath)
@@ -61,22 +98,9 @@ class PipeExecuteStrategy implements ExecuteStrategy {
     writeFileSync(this.pipePath, this.commandSerializer.serialize(cmd));
 
     const lastModified = this.getFileLastModified(this.outputPath);
-
-    // If output path does not exist, wait for it to be created
-    // Edge case, will happen only first time
-    if (!existsSync(this.outputPath)) {
-      while (!existsSync(this.outputPath)) {
-        this.sleep(PIPE_WAIT_SLEEP_TIME);
-      }
-    } else {
-      // Otherwise wait for the file to be modified
-      while (true) {
-        const lastModifiedUpdated = this.getFileLastModified(this.outputPath);
-        if (lastModified !== lastModifiedUpdated) {
-          break;
-        }
-        this.sleep(PIPE_WAIT_SLEEP_TIME);
-      }
+    const didTimeout = this.waitForOutputWithTimeout(lastModified);
+    if (didTimeout) {
+      return new CommandOutput(CommandOutputType.TimedOut, `${cmd} timed out after ${this.executionTimeout}ms`);
     }
 
     const outputData = readFileSync(this.outputPath).toString();
@@ -114,6 +138,11 @@ class PipeExecuteStrategy implements ExecuteStrategy {
     withOutputPath = (outputPath: string): this => {
       this.container.outputPath = outputPath;
       this.container.commandSerializer = new JsonSerializer(outputPath);
+      return this;
+    };
+
+    withExecutionTimeout = (executionTimeout: number): this => {
+      this.container.executionTimeout = executionTimeout;
       return this;
     };
 


### PR DESCRIPTION
Closes #1 

**Implementation**

1. Add a timeout and option to set it using the pipe executor builder.
2. Add a new type of command output - `TimedOut`. 
3. Check if execution is timed out and return output if so. 

**Side Note**

1. Expose `CommandOutputType` to public API, so it can be used by users. 